### PR TITLE
[NestedPage] Use "getParentAccessor()" in "handleRecordCreation"

### DIFF
--- a/src/ResourcePages/NestedPage.php
+++ b/src/ResourcePages/NestedPage.php
@@ -116,7 +116,7 @@ trait NestedPage
         /** @var NestedResource $resource */
         $resource = $this::getResource();
 
-        $parent = Str::camel(Str::afterLast($resource::getParent()::getModel(), '\\'));
+        $parent = $resource::getParentAccessor();
 
         // Create the model.
         $model = $this->getModel()::make($data);


### PR DESCRIPTION
The use of `getParentAccessor()` is useful when we override the original `getParentAccessor()` in the `ChildResource`, because we have a different relation name than the parent model name, for example.

Example:
- Model name: Product
- Relation name: parentProduct